### PR TITLE
fix especie do titulo - remessa itaú

### DIFF
--- a/lib/brcobranca/remessa/cnab400/itau.rb
+++ b/lib/brcobranca/remessa/cnab400/itau.rb
@@ -109,7 +109,7 @@ module Brcobranca
           detalhe << pagamento.formata_valor                                # valor do documento                    9[13]
           detalhe << cod_banco                                              # codigo banco                          9[03]
           detalhe << ''.rjust(5, '0')                                       # agencia cobradora - deixar zero       9[05]
-          detalhe << '99'                                                   # especie  do titulo                    X[02]
+          detalhe << pagamento.especie_titulo                               # especie  do titulo                    X[02]
           detalhe << aceite                                                 # aceite (A/N)                          X[01]
           detalhe << pagamento.data_emissao.strftime('%d%m%y')              # data de emissao                       9[06]
           detalhe << pagamento.cod_primeira_instrucao                       # 1a instrucao - deixar zero            X[02]


### PR DESCRIPTION
Fix para informação da especie do titulo na Remessa do Itaú.